### PR TITLE
removed operator:regexp

### DIFF
--- a/dp-file-downloader.nomad
+++ b/dp-file-downloader.nomad
@@ -16,7 +16,6 @@ job "dp-file-downloader" {
 
     constraint {
       attribute = "${node.class}"
-      operator  = "regexp"
       value     = "web"
     }
 
@@ -84,7 +83,6 @@ job "dp-file-downloader" {
 
     constraint {
       attribute = "${node.class}"
-      operator  = "regexp"
       value     = "publishing"
     }
 


### PR DESCRIPTION
### What

Updated nomad plans to removed operator:regexp and attribute:meta.has_disk.
Could not find dp-api-poc or dp-developer-poc.
https://trello.com/c/wKGU1LY5/3697-check-all-bau-services-nomad-plans

### How to review

???

### Who can review

james
