### PR TITLE
Fix health check endpoint in nomad plan

### DIFF
--- a/dp-file-downloader.nomad
+++ b/dp-file-downloader.nomad
@@ -52,7 +52,7 @@ job "dp-file-downloader" {
 
         check {
           type     = "http"
-          path     = "/healthcheck"
+          path     = "/health"
           interval = "10s"
           timeout  = "2s"
         }
@@ -119,7 +119,7 @@ job "dp-file-downloader" {
 
         check {
           type     = "http"
-          path     = "/healthcheck"
+          path     = "/health"
           interval = "10s"
           timeout  = "2s"
         }


### PR DESCRIPTION
The nomad plan was still using the old path `/healthcheck` which has now been changed to `/health` in compliance with spec.