### PR TITLE
Update application logs to use log.go v2 library

### DIFF
--- a/clients/table-renderer/client.go
+++ b/clients/table-renderer/client.go
@@ -9,7 +9,7 @@ import (
 	healthcheck "github.com/ONSdigital/dp-api-clients-go/health"
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dphttp "github.com/ONSdigital/dp-net/http"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 )
 
 const service = "table-renderer"
@@ -74,6 +74,6 @@ func (c *Client) post(ctx context.Context, uri string, body []byte) (*http.Respo
 // closeResponseBody closes the response body and logs an error containing the context if unsuccessful
 func closeResponseBody(ctx context.Context, resp *http.Response) {
 	if err := resp.Body.Close(); err != nil {
-		log.Event(ctx, "error closing http response body", log.ERROR, log.Error(err))
+		log.Error(ctx, "error closing http response body", err)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -44,7 +44,7 @@ func Get() (*Config, error) {
 
 // Log writes all config properties to log.Debug
 func (cfg *Config) Log(ctx context.Context) {
-	log.Event(ctx, "Configuration", log.INFO, log.Data{
+	log.Info(ctx, "Configuration", log.Data{
 		"BindAddr":                   cfg.BindAddr,
 		"CORSAllowedOrigins":         cfg.CORSAllowedOrigins,
 		"ShutdownTimeout":            cfg.ShutdownTimeout,

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go v1.43.0
 	github.com/ONSdigital/dp-healthcheck v1.5.0
 	github.com/ONSdigital/dp-net v1.5.0
-	github.com/ONSdigital/log.go v1.1.0
+	github.com/ONSdigital/log.go/v2 v2.3.0
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/kelseyhightower/envconfig v1.4.0
@@ -16,7 +16,6 @@ require (
 require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.187.0 // indirect
 	github.com/ONSdigital/dp-net/v2 v2.6.0 // indirect
-	github.com/ONSdigital/log.go/v2 v2.3.0 // indirect
 	github.com/aws/aws-sdk-go v1.44.76 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect

--- a/table/table.go
+++ b/table/table.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ONSdigital/dp-api-clients-go/zebedee"
 	dphandlers "github.com/ONSdigital/dp-net/handlers"
 	"github.com/ONSdigital/dp-net/request"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 )
 
 var (
@@ -60,7 +60,7 @@ func (downloader *Downloader) Download(r *http.Request) (responseBody io.ReadClo
 	// call the content server to get the json definition of the table
 	contentResponseBody, err := downloader.contentClient.GetResourceBody(ctx, userAccessToken, collectionID, lang, uri)
 	if err != nil {
-		log.Event(ctx, "error calling content server", log.ERROR, log.Error(err))
+		log.Error(ctx, "error calling content server", err)
 		var e zebedee.ErrInvalidZebedeeResponse
 		if errors.As(err, &e) {
 			if e.ActualCode == http.StatusNotFound {
@@ -74,7 +74,7 @@ func (downloader *Downloader) Download(r *http.Request) (responseBody io.ReadClo
 	// post the json definition to the renderer
 	renderResponse, err := downloader.rendererClient.PostBody(ctx, format, contentResponseBody)
 	if err != nil {
-		log.Event(ctx, "error calling renderer server", log.ERROR, log.Error(err))
+		log.Error(ctx, "error calling renderer server", err)
 		return nil, nil, http.StatusInternalServerError, err
 	}
 
@@ -86,11 +86,11 @@ func getHeaderValues(ctx context.Context, r *http.Request) (string, string, stri
 	locale := request.GetLocaleCode(r)
 	collectionID, err := request.GetCollectionID(r)
 	if err != nil {
-		log.Event(ctx, "unexpected error when getting collection id", log.ERROR, log.Error(err))
+		log.Error(ctx, "unexpected error when getting collection id", err)
 	}
 	accessToken, err := dphandlers.GetFlorenceToken(ctx, r)
 	if err != nil {
-		log.Event(ctx, "unexpected error when getting access token", log.ERROR, log.Error(err))
+		log.Error(ctx, "unexpected error when getting access token", err)
 	}
 	return locale, collectionID, accessToken
 }


### PR DESCRIPTION
### What

Update application logs to use log.go v2 library

v1 log.go library still in use as it is a transient dependency of other dependencies used in this app, namely dp-net. These other dependencies will need updating separately

### How to review

- Sanity check changes

### Who can review

Anyone
