### PR TITLE
Use version 1.26.0 in go mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ONSdigital/dp-file-downloader
 
-go 1.26.1
+go 1.26.0
 
 require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.277.0


### PR DESCRIPTION
### What

I've changed the version in go mod down from 1.26.1 to 1.26.0 so that it's using the lowest patch number.

### How to review

Sense check. Tests pass.

### Who can review

Anyone.