### PR TITLE
Fix dp-api-clients-go version to 2.273.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-file-downloader
 go 1.26.0
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.277.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.273.0
 	github.com/ONSdigital/dp-healthcheck v1.6.4
 	github.com/ONSdigital/dp-net/v3 v3.10.0
 	github.com/ONSdigital/log.go/v2 v2.5.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/ONSdigital/dp-api-clients-go/v2 v2.277.0 h1:wJ+lfVqF7rDksQ+p6adHqoXvE0Q/4ZDfifxzLC16Vh8=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.277.0/go.mod h1:bLseTP21r8LCStUEeOdVPyqtrTomOFP/azPjKWW4deA=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.273.0 h1:iCn+HYkqYDTrzBuwDuvbUYCrIpOrRcVaRsMaATEpxJs=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.273.0/go.mod h1:bLseTP21r8LCStUEeOdVPyqtrTomOFP/azPjKWW4deA=
 github.com/ONSdigital/dp-healthcheck v1.6.4 h1:FhWOuVmob36dYq7AzCdbgyf0Vk58IFitSl8y8pWJ8ck=
 github.com/ONSdigital/dp-healthcheck v1.6.4/go.mod h1:j3UNbGT4ZJg1chrRkPLE6YUVYCg1su3AAQ8frcBrvgc=
 github.com/ONSdigital/dp-mocking v0.11.0 h1:laln6e2JD4vtsYbg0cTw9ur1Xf390AUYdd85cG2UNQw=


### PR DESCRIPTION
### What

A recent issue described here: https://onswebsite.slack.com/archives/C1BK8ES15/p1776074364779459

was found to be caused by an upgrade to the Release Calendar API. Some investigation into this found that versions of dp-api-client-go that are >= v2.273.1 can cause Florence to break. Therefore this service is being restricted to version 2.273.0 of dp-api-clients-go by this PR.

### How to review

Sense check. Tests pass.

### Who can review

Anyone.