### PR TITLE
Upgrade to use go 1.26.3

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -127,8 +127,9 @@ func handleDownload(handler func(r *http.Request) (io.ReadCloser, map[string]str
 				}
 			}
 		}()
+		requestLabel := "request:"
 		if err != nil {
-			log.Error(ctx, "handleDownload: Error returned from handler", err, log.Data{"request:": request})
+			log.Error(ctx, "handleDownload: Error returned from handler", err, log.Data{requestLabel: request})
 			if status < 400 {
 				status = http.StatusInternalServerError
 			}
@@ -141,7 +142,7 @@ func handleDownload(handler func(r *http.Request) (io.ReadCloser, map[string]str
 			// write body
 			_, err := io.Copy(w, reader)
 			if err != nil {
-				log.Error(ctx, "handleDownload: Error while copying from reader", err, log.Data{"request:": request})
+				log.Error(ctx, "handleDownload: Error while copying from reader", err, log.Data{requestLabel: request})
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}

--- a/api/api.go
+++ b/api/api.go
@@ -127,7 +127,7 @@ func handleDownload(handler func(r *http.Request) (io.ReadCloser, map[string]str
 				}
 			}
 		}()
-		requestLabel := "request:"
+		const requestLabel = "request"
 		if err != nil {
 			log.Error(ctx, "handleDownload: Error returned from handler", err, log.Data{requestLabel: request})
 			if status < 400 {

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.2-bookworm
+    tag: 1.26.3-bookworm
 
 inputs:
   - name: dp-file-downloader

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.2-bookworm
+    tag: 1.26.3-bookworm
 
 inputs:
   - name: dp-file-downloader

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-lint-go
-    tag: 1.26.2-bookworm-golangci-lint-2
+    tag: 1.26.3-bookworm-golangci-lint-2
 
 inputs:
   - name: dp-file-downloader

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.2-bookworm
+    tag: 1.26.3-bookworm
 
 inputs:
   - name: dp-file-downloader

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -28,6 +28,11 @@ var (
 	baseURL               = "http://localhost/download/table?format="
 )
 
+const (
+	accessTokenLabel = "access_token"
+	testUrl          = "test/url"
+)
+
 func createZebedeeClientMock(body string, err error) *testdata.ZebedeeClientMock {
 	return &testdata.ZebedeeClientMock{
 		GetResourceBodyFunc: func(ctx context.Context, userAccessToken string, collectionID string, lang string, uri string) ([]byte, error) {
@@ -50,7 +55,7 @@ func TestSuccessfulDownload(t *testing.T) {
 	t.Parallel()
 	Convey("Given a TableDownloader and a request to download a table", t, func() {
 		initialRequest, err := http.NewRequest("GET", baseURL+requestFormat+uriParam+requestURI, http.NoBody)
-		initialRequest.AddCookie(&http.Cookie{Name: "access_token", Value: accessToken})
+		initialRequest.AddCookie(&http.Cookie{Name: accessTokenLabel, Value: accessToken})
 		So(err, ShouldBeNil)
 
 		contentClient := createZebedeeClientMock(contentServerResponse, nil)
@@ -86,7 +91,7 @@ func TestSuccessfulDownloadForSpecificCollection(t *testing.T) {
 		contentCollection := "myCollection"
 
 		initialRequest, err := http.NewRequest("GET", baseURL+requestFormat+uriParam+requestURI, http.NoBody)
-		initialRequest.AddCookie(&http.Cookie{Name: "access_token", Value: accessToken})
+		initialRequest.AddCookie(&http.Cookie{Name: accessTokenLabel, Value: accessToken})
 		initialRequest.AddCookie(&http.Cookie{Name: "collection", Value: contentCollection})
 		So(err, ShouldBeNil)
 
@@ -123,10 +128,10 @@ func TestMissingContent(t *testing.T) {
 		requestURI := "/foo/bar"
 
 		initialRequest, err := http.NewRequest("GET", baseURL+requestFormat+uriParam+requestURI, http.NoBody)
-		initialRequest.AddCookie(&http.Cookie{Name: "access_token", Value: accessToken})
+		initialRequest.AddCookie(&http.Cookie{Name: accessTokenLabel, Value: accessToken})
 		So(err, ShouldBeNil)
 
-		contentClient := createZebedeeClientMock("", zebedee.ErrInvalidZebedeeResponse{ActualCode: http.StatusNotFound, URI: "test/url"})
+		contentClient := createZebedeeClientMock("", zebedee.ErrInvalidZebedeeResponse{ActualCode: http.StatusNotFound, URI: testUrl})
 		renderClient := createTableRenderClientMock(http.StatusOK, "", "", nil)
 
 		testObj := table.NewDownloader(contentClient, renderClient)
@@ -149,9 +154,9 @@ func TestContentServerError(t *testing.T) {
 		initialRequest, err := http.NewRequest("GET", "http://localhost/download/table?format=html&uri=/foo/bar", http.NoBody)
 		So(err, ShouldBeNil)
 
-		expectedErr := zebedee.ErrInvalidZebedeeResponse{ActualCode: http.StatusInternalServerError, URI: "test/url"}
+		expectedErr := zebedee.ErrInvalidZebedeeResponse{ActualCode: http.StatusInternalServerError, URI: testUrl}
 
-		contentClient := createZebedeeClientMock("", zebedee.ErrInvalidZebedeeResponse{ActualCode: http.StatusInternalServerError, URI: "test/url"})
+		contentClient := createZebedeeClientMock("", zebedee.ErrInvalidZebedeeResponse{ActualCode: http.StatusInternalServerError, URI: testUrl})
 		renderClient := createTableRenderClientMock(http.StatusOK, "", "", nil)
 
 		testObj := table.NewDownloader(contentClient, renderClient)
@@ -198,10 +203,10 @@ func TestBadlyFormedRequest(t *testing.T) {
 		requestFormat := "html"
 
 		initialRequest, err := http.NewRequest("GET", "http://localhost/download/table?format="+requestFormat+uriParam+requestURI, http.NoBody)
-		initialRequest.AddCookie(&http.Cookie{Name: "access_token", Value: accessToken})
+		initialRequest.AddCookie(&http.Cookie{Name: accessTokenLabel, Value: accessToken})
 		So(err, ShouldBeNil)
 
-		contentClient := createZebedeeClientMock("", zebedee.ErrInvalidZebedeeResponse{ActualCode: http.StatusBadRequest, URI: "test/url"})
+		contentClient := createZebedeeClientMock("", zebedee.ErrInvalidZebedeeResponse{ActualCode: http.StatusBadRequest, URI: testUrl})
 		renderClient := createTableRenderClientMock(http.StatusOK, "", "", nil)
 
 		testObj := table.NewDownloader(contentClient, renderClient)


### PR DESCRIPTION
### What

Jira ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-4951

The version of go has been increased from 1.26.2 to 1.26.3, to fix audit failures.

### How to review

Sense check. Tests pass.

### Who can review

Anyone.